### PR TITLE
laravel breezeのプロフィール編集画面のカスタム

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
 use Inertia\Inertia;
 use Inertia\Response;
+use Cloudinary;
 
 class ProfileController extends Controller
 {
@@ -38,6 +39,24 @@ class ProfileController extends Controller
         $request->user()->save();
 
         return Redirect::route('profile.edit');
+        //画像アップロード検討中
+        
+        // $validatedData = $request->except('image');
+        // $request->user()->fill($validatedData);
+        
+        // if ($request->hasFile('image')) {
+        //     $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
+        //     dd($image_url);
+        //     $request->user()->image_url = $image_url;
+        // }
+        
+        // if ($request->user()->isDirty('email')) {
+        //     $request->user()->email_verified_at = null;
+        // }
+
+        // $request->user()->save();
+
+        // return Redirect::route('profile.edit');
     }
 
     /**

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -18,6 +18,9 @@ class ProfileUpdateRequest extends FormRequest
         return [
             'name' => ['string', 'max:255'],
             'email' => ['email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
+            'text' => ['string', 'max:500'],
+            'goal_text' => ['string', 'max:100'],
+            'goal_time' => ['integer'],
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,10 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'image_url',
+        'text',
+        'goal_text',
+        'goal_time',
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.0.2",
+        "cloudinary-labs/cloudinary-laravel": "^2.0",
         "guzzlehttp/guzzle": "^7.2",
         "inertiajs/inertia-laravel": "^0.6.3",
         "laravel/framework": "^9.19",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9bd17e838f30e400a51be1d79f8286d5",
+    "content-hash": "9803f22c54b6a55a2f7ce776c65a1e31",
     "packages": [
         {
             "name": "brick/math",
@@ -60,6 +60,202 @@
                 }
             ],
             "time": "2023-01-15T23:15:59+00:00"
+        },
+        {
+            "name": "cloudinary-labs/cloudinary-laravel",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cloudinary-devs/cloudinary-laravel.git",
+                "reference": "f331b770b277a75dbde3c61bf1e50096b3e68104"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary-devs/cloudinary-laravel/zipball/f331b770b277a75dbde3c61bf1e50096b3e68104",
+                "reference": "f331b770b277a75dbde3c61bf1e50096b3e68104",
+                "shasum": ""
+            },
+            "require": {
+                "cloudinary/cloudinary_php": "^2.0",
+                "ext-json": "*",
+                "illuminate/support": "~6|~7|~8|^9.0|^10.0",
+                "php": "^8.0.2"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.1",
+                "orchestra/testbench": "~4|~5|~6|^7.0",
+                "phpunit/phpunit": "^8.0|^9.5.10",
+                "sempro/phpunit-pretty-print": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "CloudinaryLabs\\CloudinaryLaravel\\CloudinaryServiceProvider"
+                    ],
+                    "aliases": {
+                        "Cloudinary": "CloudinaryLabs\\CloudinaryLaravel\\Facades\\Cloudinary"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Support/helpers.php"
+                ],
+                "psr-4": {
+                    "CloudinaryLabs\\CloudinaryLaravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Prosper Otemuyiwa",
+                    "email": "prosperotemuyiwa@gmail.com",
+                    "homepage": "https://github.com/unicodeveloper"
+                }
+            ],
+            "description": "A Laravel Cloudinary Package",
+            "homepage": "https://github.com/cloudinary-labs/cloudinary-laravel",
+            "keywords": [
+                "File Transformations",
+                "Media management",
+                "cloudinary",
+                "cloudinary-laravel",
+                "file uploads",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/cloudinary-devs/cloudinary-laravel/issues",
+                "source": "https://github.com/cloudinary-devs/cloudinary-laravel/tree/2.0.3"
+            },
+            "time": "2023-03-01T15:07:23+00:00"
+        },
+        {
+            "name": "cloudinary/cloudinary_php",
+            "version": "2.12.0",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:cloudinary/cloudinary_php.git",
+                "reference": "57290a5e24bee1d65939713f6ef8f75d93f2d6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary/cloudinary_php/zipball/57290a5e24bee1d65939713f6ef8f75d93f2d6b6",
+                "reference": "57290a5e24bee1d65939713f6ef8f75d93f2d6b6",
+                "shasum": ""
+            },
+            "require": {
+                "cloudinary/transformation-builder-sdk": "^1",
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.5.8|^7.4.5",
+                "guzzlehttp/promises": "^1.5.3|^2.0",
+                "guzzlehttp/psr7": "^1.9.1|^2.5",
+                "monolog/monolog": "^1|^2|^3",
+                "php": ">=5.6.0",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "consolidation/robo": "~1",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "*",
+                "phpmd/phpmd": "*",
+                "squizlabs/php_codesniffer": "3.*",
+                "symfony/phpunit-bridge": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cloudinary",
+                    "homepage": "https://github.com/cloudinary/cloudinary_php/graphs/contributors"
+                }
+            ],
+            "description": "Cloudinary PHP SDK",
+            "homepage": "https://github.com/cloudinary/cloudinary_php",
+            "keywords": [
+                "cdn",
+                "cloud",
+                "cloudinary",
+                "image management",
+                "sdk"
+            ],
+            "support": {
+                "email": "info@cloudinary.com",
+                "issues": "https://github.com/cloudinary/cloudinary_php/issues"
+            },
+            "time": "2023-12-03T13:57:09+00:00"
+        },
+        {
+            "name": "cloudinary/transformation-builder-sdk",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:cloudinary/php-transformation-builder-sdk.git",
+                "reference": "5cb90466be7f2ff35b02977295750504f8085b46"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cloudinary/php-transformation-builder-sdk/zipball/5cb90466be7f2ff35b02977295750504f8085b46",
+                "reference": "5cb90466be7f2ff35b02977295750504f8085b46",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "consolidation/robo": "~1",
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "*",
+                "phpmd/phpmd": "*",
+                "squizlabs/php_codesniffer": "3.*",
+                "symfony/phpunit-bridge": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cloudinary",
+                    "homepage": "https://github.com/cloudinary/php-transformation-builder-sdk/graphs/contributors"
+                }
+            ],
+            "description": "Cloudinary PHP Transformation Builder SDK",
+            "homepage": "https://github.com/cloudinary/php-transformation-builder-sdk",
+            "keywords": [
+                "cdn",
+                "cloud",
+                "cloudinary",
+                "image management",
+                "sdk"
+            ],
+            "support": {
+                "email": "info@cloudinary.com",
+                "issues": "https://github.com/cloudinary/php-transformation-builder-sdk/issues"
+            },
+            "time": "2023-10-04T13:11:09+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/config/app.php
+++ b/config/app.php
@@ -185,7 +185,7 @@ return [
         /*
          * Package Service Providers...
          */
-
+        CloudinaryLabs\CloudinaryLaravel\CloudinaryServiceProvider::class,
         /*
          * Application Service Providers...
          */

--- a/config/cloudinary.php
+++ b/config/cloudinary.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Laravel Cloudinary package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cloudinary Configuration
+    |--------------------------------------------------------------------------
+    |
+    | An HTTP or HTTPS URL to notify your application (a webhook) when the process of uploads, deletes, and any API
+    | that accepts notification_url has completed.
+    |
+    |
+    */
+    'notification_url' => env('CLOUDINARY_NOTIFICATION_URL'),
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cloudinary Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your Cloudinary settings. Cloudinary is a cloud hosted
+    | media management service for all file uploads, storage, delivery and transformation needs.
+    |
+    |
+    */
+    'cloud_url' => env('CLOUDINARY_URL'),
+
+    /**
+     * Upload Preset From Cloudinary Dashboard
+     *
+     */
+    'upload_preset' => env('CLOUDINARY_UPLOAD_PRESET'),
+
+];

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -16,10 +16,10 @@ return new class extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->string('image', 2000)->nullable();
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->string('image_url')->nullable();
             $table->string('text', 500)->nullable();
             $table->string('goal_text', 100)->nullable();
             $table->integer('goal_time')->nullable();

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -11,6 +11,9 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
     const { data, setData, patch, errors, processing, recentlySuccessful } = useForm({
         name: user.name,
         email: user.email,
+        text: user.text,
+        goal_text: user.goal_text,
+        goal_time: user.goal_time,
     });
 
     const submit = (e) => {
@@ -29,7 +32,7 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
                 </p>
             </header>
 
-            <form onSubmit={submit} className="mt-6 space-y-6">
+            <form onSubmit={submit} className="mt-6 space-y-6" encType="multipart/form-data">
                 <div>
                     <InputLabel htmlFor="name" value="Name" />
 
@@ -56,10 +59,51 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
                         value={data.email}
                         onChange={(e) => setData('email', e.target.value)}
                         required
-                        autoComplete="username"
                     />
 
                     <InputError className="mt-2" message={errors.email} />
+                </div>
+
+                <div>
+                    <InputLabel htmlFor="text" value="自己紹介文" />
+
+                    <TextInput
+                        id="text"
+                        className="mt-1 block w-full"
+                        value={data.text}
+                        onChange={(e) => setData('text', e.target.value)}
+                        isFocused
+                    />
+
+                    <InputError className="mt-2" message={errors.text} />
+                </div>
+                <div>
+                    <InputLabel htmlFor="goal_text" value="目標" />
+
+                    <TextInput
+                        id="goal_text"
+                        className="mt-1 block w-full"
+                        value={data.goal_text}
+                        onChange={(e) => setData('goal_text', e.target.value)}
+                        isFocused
+                    />
+
+                    <InputError className="mt-2" message={errors.goal_text} />
+                </div>
+
+                <div>
+                    <InputLabel htmlFor="goal_time" value="目標時間" />
+
+                    <TextInput
+                        id="goal_time"
+                        type="number"
+                        className="mt-1 block w-full"
+                        value={data.goal_time}
+                        onChange={(e) => setData('goal_time', e.target.value)}
+                        isFocused
+                    />
+
+                    <InputError className="mt-2" message={errors.goal_time} />
                 </div>
 
                 {mustVerifyEmail && user.email_verified_at === null && (

--- a/resources/js/Pages/StudyRecord/Index.jsx
+++ b/resources/js/Pages/StudyRecord/Index.jsx
@@ -16,6 +16,16 @@ export default function Index(props) {
           }
         >
             <Head title="Study_records Index" />
+            <div className="py-10">
+                <div className="w-5/6 m-auto my-5 text-center">
+                    <div className="p-3 bg-cyan-200 rounded-t-lg">目標</div>
+                    <div className="p-5 bg-slate-50 rounded-b-lg">{props.auth.user.goal_text}</div>
+                </div>
+                <div className="w-5/6 m-auto my-5 text-center">
+                    <div className="p-3 bg-cyan-200 rounded-t-lg">目標時間</div>
+                    <div className="p-5 bg-slate-50 rounded-b-lg">{props.auth.user.goal_time}</div>
+                </div>
+            </div>
             <div className="py-20">
             <div className="w-5/6 m-auto p-10 bg-slate-50 rounded-lg">
                 <div className="flex justify-between mb-10 text-center">

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,25 +35,23 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
-});
-
-Route::resource('/study_records', StudyRecordController::class)
-    ->names(['index' => 'study_record.index',
-            'create' => 'study_record.create',
-            'store' => 'study_record.store',
-            'destroy' => 'study_record.destroy',
-            'edit' => 'study_record.edit',
-            'update' => 'study_record.update',
-            'show' => 'study_record.show'
-            ])
-    ->middleware('auth');
     
-Route::resource('/category', CategoryController::class)
-    ->names(['index' => 'category.index',
-            'create' => 'category.create',
-            'store' => 'category.store',
-            'destroy' => 'category.destroy',
-            ])
-    ->middleware('auth');
+    Route::resource('/study_records', StudyRecordController::class)
+        ->names(['index' => 'study_record.index',
+                'create' => 'study_record.create',
+                'store' => 'study_record.store',
+                'destroy' => 'study_record.destroy',
+                'edit' => 'study_record.edit',
+                'update' => 'study_record.update',
+                'show' => 'study_record.show'
+                ]);
+    
+    Route::resource('/category', CategoryController::class)
+        ->names(['index' => 'category.index',
+                'create' => 'category.create',
+                'store' => 'category.store',
+                'destroy' => 'category.destroy',
+                ]);
+});
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
まず、web.phpを整えた。
次に、プロフィール編集画面にtext, goal_text, goal_timeを設定できるようにした。
プロフィール画像を転送し、cloudinaryに保存して表示させたかったが、fileの形式のデータが送れなかったため、プロフィール画像なしでの実装にした。プロフィール画像は後に調べて実装する。