### PR TITLE
コメント機能の追加

### DIFF
--- a/app/Http/Controllers/StudyRecordCommentController.php
+++ b/app/Http/Controllers/StudyRecordCommentController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Http\Requests\CommentRequest;
+use App\Models\StudyRecordComment;
+
+class StudyRecordCommentController extends Controller
+{
+    public function store(CommentRequest $request, $study_record, StudyRecordComment $comment) {
+        $data = $request->all();
+        $data['user_id'] = auth()->id();
+        $data['study_record_id'] = $study_record;
+        
+        $comment->fill($data);
+        $comment->save();
+        
+        return redirect()->route('study_record.show', $study_record);
+    }
+    
+    public function destroy($study_record, StudyRecordComment $comment) {
+        $comment->delete();
+        
+        return redirect()->route('study_record.show', $study_record);
+    }
+}

--- a/app/Http/Controllers/StudyRecordController.php
+++ b/app/Http/Controllers/StudyRecordController.php
@@ -16,7 +16,7 @@ class StudyRecordController extends Controller
     }
     
     public function show($id) {
-        $study_record = StudyRecord::with('user', 'categories', 'study_record_likes')->where('id', $id)->first();
+        $study_record = StudyRecord::with('user', 'categories', 'study_record_likes', 'study_record_comments.user')->where('id', $id)->first();
         
         return Inertia::render('StudyRecord/Show', ['study_record' => $study_record]);
     }

--- a/app/Http/Requests/CommentRequest.php
+++ b/app/Http/Requests/CommentRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CommentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'comment' => 'required',
+        ];
+    }
+    
+    public function messages() {
+        return [
+            'comment.required' => '内容は必須です',
+        ];
+    }
+}

--- a/app/Models/StudyRecord.php
+++ b/app/Models/StudyRecord.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use App\Models\User;
 use App\Models\Category;
 use App\Models\StudyRecordLike;
+use App\Models\StudyRecordComment;
 
 class StudyRecord extends Model
 {
@@ -31,5 +32,9 @@ class StudyRecord extends Model
     
     public function study_record_likes() {
         return $this->hasMany(StudyRecordLike::class);
+    }
+    
+    public function study_record_comments() {
+        return $this->hasMany(StudyRecordComment::class);
     }
 }

--- a/app/Models/StudyRecordComment.php
+++ b/app/Models/StudyRecordComment.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Support\Carbon;
+use App\Models\User;
+use App\Models\StudyRecord;
+
+class StudyRecordComment extends Model
+{
+    use HasFactory;
+    
+    protected $fillable = [
+        'user_id',
+        'study_record_id',
+        'comment',
+    ];
+    
+    public function user() {
+        return $this->belongsTo(User::class);
+    }
+    
+    public function study_record() {
+        return $this->belongsTo(StudyRecord::class);
+    }
+    
+    protected function createdAt(): Attribute {
+        return Attribute::make(
+            get: fn ($value) => Carbon::parse($value)->format('Y-m-d H:i:s'),
+        );
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,7 +9,8 @@ use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\StudyRecord;
 use App\Models\NoteRecord;
-use App\Models\StudyRecordUserLike;
+use App\Models\StudyRecordLike;
+use App\Models\StudyRecordComment;
 
 class User extends Authenticatable
 {
@@ -34,13 +35,18 @@ class User extends Authenticatable
         return $this->hasMany(StudyRecord::class);  
     }
     
+    public function study_record_user_likes() {
+        return $this->hasMany(StudyRecordLike::class);
+    }
+    
+    public function study_record_comments() {
+        return $this->hasMany(StudyRecordComment::class);
+    }
+    
     public function note_records() {    
         return $this->hasMany(NoteRecord::class);  
     }
     
-    public function study_record_user_likes() {
-        return $this->hasMany(StudyRecordUserLike::class);
-    }
     /**
      * The attributes that should be hidden for serialization.
      *

--- a/database/migrations/2023_11_16_052216_create_study_records_table.php
+++ b/database/migrations/2023_11_16_052216_create_study_records_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('study_records', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
             $table->date('date');
             $table->integer('time');
             $table->string('title', 50);

--- a/database/migrations/2023_11_16_052411_create_study_record_comments_table.php
+++ b/database/migrations/2023_11_16_052411_create_study_record_comments_table.php
@@ -15,8 +15,8 @@ return new class extends Migration
     {
         Schema::create('study_record_comments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
-            $table->foreignId('study_record_id')->constrained();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('study_record_id')->constrained()->onDelete('cascade');
             $table->string('comment', 100);
             $table->timestamps();
         });

--- a/database/migrations/2023_11_16_052443_create_note_records_table.php
+++ b/database/migrations/2023_11_16_052443_create_note_records_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
     {
         Schema::create('note_records', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
             $table->date('date');
             $table->string('title', 50);
             $table->string('body', 500);

--- a/database/migrations/2023_11_16_052544_create_note_record_comments_table.php
+++ b/database/migrations/2023_11_16_052544_create_note_record_comments_table.php
@@ -15,8 +15,8 @@ return new class extends Migration
     {
         Schema::create('note_record_comments', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
-            $table->foreignId('note_record_id')->constrained();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('note_record_id')->constrained()->onDelete('cascade');
             $table->string('comment', 100);
             $table->timestamps();
         });

--- a/database/migrations/2023_11_16_052836_create_relationships_table.php
+++ b/database/migrations/2023_11_16_052836_create_relationships_table.php
@@ -15,8 +15,8 @@ return new class extends Migration
     {
         Schema::create('relationships', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('followed_user_id')->constrained('users');
-            $table->foreignId('folloing_user_id')->constrained('users');
+            $table->foreignId('followed_user_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('folloing_user_id')->constrained('users')->onDelete('cascade');
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_12_13_094150_create_study_record_likes_table.php
+++ b/database/migrations/2023_12_13_094150_create_study_record_likes_table.php
@@ -15,8 +15,8 @@ return new class extends Migration
     {
         Schema::create('study_record_likes', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
-            $table->foreignId('study_record_id')->constrained();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('study_record_id')->constrained()->onDelete('cascade');
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_12_13_094212_create_note_record_likes_table.php
+++ b/database/migrations/2023_12_13_094212_create_note_record_likes_table.php
@@ -15,8 +15,8 @@ return new class extends Migration
     {
         Schema::create('note_record_likes', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained();
-            $table->foreignId('note_record_id')->constrained();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('note_record_id')->constrained()->onDelete('cascade');
             $table->timestamps();
         });
     }

--- a/resources/js/Pages/StudyRecord/Create.jsx
+++ b/resources/js/Pages/StudyRecord/Create.jsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, useForm} from '@inertiajs/react';
+import { Head, useForm } from '@inertiajs/react';
 import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
 import TextInput from '@/Components/TextInput';

--- a/resources/js/Pages/StudyRecord/Index.jsx
+++ b/resources/js/Pages/StudyRecord/Index.jsx
@@ -58,19 +58,18 @@ export default function Index(props) {
                 <div className="p-6 bg-white border-t border-gray-200 overflow-y-auto" style={{ maxHeight: '500px' }}>
                     {props.study_records.sort((a, b) => new Date(b.date) - new Date(a.date)).map((study_record) => { return (
                         <Link key={study_record.id} href={route("study_record.show", study_record.id)}>
-                            <div className="bg-red-500 p-7 m-5 sm:rounded-lg relative">
-                                <div className="absolute top-0 left-0 flex text-white text-sm font-bold p-3">
-                                    <div class="relative w-8 h-8 overflow-hidden rounded-full bg-gray-200">
-                                      <img
-                                        class="absolute inset-0 w-full h-full object-cover rounded-full"
+                            <div className="bg-red-500 m-5 sm:rounded-lg">
+                                <div className="flex place-items-center text-white text-sm font-bold pt-3 px-3">
+                                    <img
+                                        className="relative w-8 h-8 rounded-full ring-2 ring-white"
                                         src={study_record.user.image_url ? study_record.user.image_url : '/images/user_icon.png'}
                                         alt=""
-                                      />
-                                    </div>
-                                    <div>{study_record.date}</div>
-                                    <div className="flex">{study_record.categories.map((category) => <div className="bg-lime-300 text-black rounded-lg mx-1">{category.name}</div>)}</div>
+                                    />
+                                    <div className="mx-2">{study_record.user.name}</div>
+                                    <div className="mx-2">{study_record.date}</div>
+                                    <div className="flex">{study_record.categories.map((category) => <div className="bg-lime-300 text-black rounded-full px-2 py-1 mx-2">{category.name}</div>)}</div>
                                 </div>
-                                <div className="flex justify-evenly">
+                                <div className="pt-1 pb-5 flex justify-evenly">
                                     <div className="text-white text-lg font-bold text-center">時間：{study_record.time}分</div>
                                     <div className="text-white text-lg font-bold text-center">{study_record.title}</div>
                                 </div>

--- a/resources/js/Pages/StudyRecord/Show.jsx
+++ b/resources/js/Pages/StudyRecord/Show.jsx
@@ -1,11 +1,25 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { Head, Link, useForm } from '@inertiajs/react';
+import InputError from '@/Components/InputError';
+import InputLabel from '@/Components/InputLabel';
+import PrimaryButton from '@/Components/PrimaryButton';
 
 export default function Show(props) {
-    const { delete: destroy, post } = useForm();
+    const { data, setData, delete: destroy, post, processing, errors } = useForm({
+        comment: ''
+    });
     
     const handleDelete = (id) => {
         destroy(route("study_record.destroy", id));
+    };
+
+    const submit = async (e) => {
+        e.preventDefault();
+        await post(route('study_record.comment.store',{ study_record: props.study_record.id }));
+    };
+    
+    const handleCommentDelete = async (study_record, comment) => {
+        await destroy(route("study_record.comment.destroy", { study_record: study_record, comment: comment }));
     };
     
     const handleLike = async (id) => {
@@ -67,6 +81,57 @@ export default function Show(props) {
                     >
                         削除
                     </button>
+                </div>
+                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8 mb-5">
+                    <form onSubmit={submit}>
+                        <div className="mt-4">
+                            <InputLabel htmlFor="comment" value="コメント" />
+                                
+                            <textarea
+                                id="comment"
+                                name="comment"
+                                value={data.comment}
+                                className="mt-1 block w-full"
+                                onChange={(e) => setData(e.target.name, e.target.value)}
+                            />
+                                
+                            <InputError message={errors.comment} className="mt-2" />
+                        </div>
+                        <div className="flex justify-end mt-4">
+                            <PrimaryButton type="submit" className="ml-4" processing={processing}>
+                                コメントする
+                            </PrimaryButton>
+                        </div>
+                    </form>
+                </div>
+                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                    { props.study_record.study_record_comments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)).map((study_record_comment) => { return (
+                        <div className="border-t border-slate-300 p-3 flex">
+                            <img
+                                className="flex-none inline-block w-8 h-8 rounded-full ring-2 ring-white"
+                                src={ study_record_comment.user.image_url ? study_record_comment.user.image_url : '/images/user_icon.png'}
+                                alt=""
+                            />
+                            <div className="flex-auto px-3 py-1">
+                                <div className="flex justify-between">
+                                    <div className="flex">
+                                        <div className="mr-5">{study_record_comment.user.name}</div>
+                                        <div>{study_record_comment.created_at}</div>
+                                    </div>
+                                    { study_record_comment.user.id === props.auth.user.id && (
+                                        <div>
+                                          <Link className="underline" onClick={() => handleCommentDelete(props.study_record.id, study_record_comment.id)}>
+                                            削除する
+                                          </Link>
+                                        </div>
+                                    )}
+                                </div>
+                                <div className="py-5">
+                                    <p>{study_record_comment.comment}</p>
+                                </div>
+                            </div>
+                        </div>
+                    ); })}
                 </div>
             </div>
         </AuthenticatedLayout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\StudyRecordController;
 use App\Http\Controllers\StudyRecordLikeController;
+use App\Http\Controllers\StudyRecordCommentController;
 use App\Http\Controllers\CategoryController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
@@ -50,6 +51,9 @@ Route::middleware('auth')->group(function () {
         
     Route::post('/study_records/{study_record}/likes', [StudyRecordLikeController::class, 'store'])->name('study_record.likes.store');
     Route::delete('/study_records/{study_record}/likes', [StudyRecordLikeController::class, 'destroy'])->name('study_record.likes.destroy');
+    
+    Route::post('/study_records/{study_record}/comments', [StudyRecordCommentController::class, 'store'])->name('study_record.comment.store');
+    Route::delete('/study_records/{study_record}/comments/{comment}', [StudyRecordCommentController::class, 'destroy'])->name('study_record.comment.destroy');
     
     Route::resource('/category', CategoryController::class)
         ->names([


### PR DESCRIPTION
study_recordのコメント機能（作成、削除）を実装した。
ルートとコントローラーの関係を調べ、より見やすい形にした。他の機能のルートとコントローラーもコメント機能と同様の形式にして可読性を上げたい。

各テーブルにおいて、データが削除された時に関連するデータも削除されるようにonDelete('cascade')を加えた。

また、ユーザーのアイコンをtailwindのサイトに載っているcssを参考に整えた。

フロントエンドでは、非同期の処理として、asyncを使っているが、検討中である。
