### PR TITLE
ユーザー画面の作成

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use App\Models\User;
+
+class UserController extends Controller
+{
+    public function show($study_record) {
+        $user = User::with('study_records.categories')->where('id', $study_record)->first();
+        
+        return Inertia::render('User/Show', ['user' => $user]);
+    }
+}

--- a/resources/js/Pages/StudyRecord/Index.jsx
+++ b/resources/js/Pages/StudyRecord/Index.jsx
@@ -60,11 +60,13 @@ export default function Index(props) {
                         <Link key={study_record.id} href={route("study_record.show", study_record.id)}>
                             <div className="bg-red-500 m-5 sm:rounded-lg">
                                 <div className="flex place-items-center text-white text-sm font-bold pt-3 px-3">
-                                    <img
-                                        className="relative w-8 h-8 rounded-full ring-2 ring-white"
-                                        src={study_record.user.image_url ? study_record.user.image_url : '/images/user_icon.png'}
-                                        alt=""
-                                    />
+                                    <Link href={route("user.show", study_record.user.id)}>
+                                        <img
+                                            className="relative w-8 h-8 rounded-full ring-2 ring-white"
+                                            src={study_record.user.image_url ? study_record.user.image_url : '/images/user_icon.png'}
+                                            alt=""
+                                        />
+                                    </Link>
                                     <div className="mx-2">{study_record.user.name}</div>
                                     <div className="mx-2">{study_record.date}</div>
                                     <div className="flex">{study_record.categories.map((category) => <div className="bg-lime-300 text-black rounded-full px-2 py-1 mx-2">{category.name}</div>)}</div>

--- a/resources/js/Pages/StudyRecord/Show.jsx
+++ b/resources/js/Pages/StudyRecord/Show.jsx
@@ -47,7 +47,14 @@ export default function Show(props) {
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
                     <div className="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                         <div className="p-6 bg-white border-b border-gray-200">
-                            <div>{props.study_record.user.name}</div>
+                            <Link href={route("user.show", props.study_record.user.id)} className="item-center">
+                                <img
+                                    className="inline w-8 h-8 rounded-full ring-2 ring-slate-100"
+                                    src={props.study_record.user.image_url ? props.study_record.user.image_url : '/images/user_icon.png'}
+                                    alt=""
+                                />
+                                <div className="inline px-3">{props.study_record.user.name}</div>
+                            </Link>
                             <div>{props.study_record.categories.map((category) => category.name)}</div>
                             <div>{props.study_record.date}</div>
                             <div>{props.study_record.time}</div>

--- a/resources/js/Pages/User/Show.jsx
+++ b/resources/js/Pages/User/Show.jsx
@@ -1,0 +1,61 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, Link } from '@inertiajs/react';
+
+export default function Show(props) {
+    return (
+        <AuthenticatedLayout
+            auth={props.auth}
+            errors={props.errors}
+            header={
+            <h2 className="font-semibold text-xl text-gray-800 leading-tight">
+                User
+            </h2>
+            }
+        >
+            <Head title="User Show" />
+            <div className="py-12">
+                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                    <div className="bg-white shadow-sm sm:rounded-lg">
+                        <div className="flex items-center p-10 border-b ">
+                            <img
+                                className="relative w-16 h-16 rounded-full ring-2 ring-slate-100"
+                                src={props.user.image_url ? props.user.image_url : '/images/user_icon.png'}
+                                alt=""
+                            />
+                            <div className="flex-auto ml-5 text-2xl">{props.user.name}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div className="py-20">
+                <div className="w-5/6 m-auto p-10 bg-slate-50 rounded-lg">
+                    <div className="text-center">タイムライン</div>
+                    <div className="p-6 bg-white border-t border-gray-200 overflow-y-auto" style={{ maxHeight: '500px' }}>
+                        {props.user.study_records.sort((a, b) => new Date(b.date) - new Date(a.date)).map((study_record) => { return (
+                            <Link key={study_record.id} href={route("study_record.show", study_record.id)}>
+                                <div className="bg-red-500 m-5 sm:rounded-lg">
+                                    <div className="flex place-items-center text-white text-sm font-bold pt-3 px-3">
+                                        <Link href={route("user.show", props.user.id)}>
+                                            <img
+                                                className="relative w-8 h-8 rounded-full ring-2 ring-white"
+                                                src={props.user.image_url ? props.user.image_url : '/images/user_icon.png'}
+                                                alt=""
+                                            />
+                                        </Link>
+                                        <div className="mx-2">{props.user.name}</div>
+                                        <div className="mx-2">{study_record.date}</div>
+                                        <div className="flex">{study_record.categories.map((category) => <div className="bg-lime-300 text-black rounded-full px-2 py-1 mx-2">{category.name}</div>)}</div>
+                                    </div>
+                                    <div className="pt-1 pb-5 flex justify-evenly">
+                                        <div className="text-white text-lg font-bold text-center">時間：{study_record.time}分</div>
+                                        <div className="text-white text-lg font-bold text-center">{study_record.title}</div>
+                                    </div>
+                                </div>
+                            </Link>
+                        ); })}
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\UserController;
 use App\Http\Controllers\StudyRecordController;
 use App\Http\Controllers\StudyRecordLikeController;
 use App\Http\Controllers\StudyRecordCommentController;
@@ -37,6 +38,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::match(['patch', 'post'], '/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    
+    Route::get('/user/{user}', [UserController::class, 'show'])->name('user.show');
     
     Route::resource('/study_records', StudyRecordController::class)
         ->names([


### PR DESCRIPTION
フォロー機能を実装するために各ユーザー画面を実装した。
ユーザーの情報とユーザーが投稿したstudy_recordsを表示させた。
また、投稿のユーザーアイコンをLinkにしてページ遷移するようにした。

showメソッドはdestroyメソッドなどと比べて引数の厳密な制限がないため、$idでも通るが、ルートで/study_records/{study_record}にしているため、引数は$study_recordにした。