### PR TITLE
フォロー機能の実装

### DIFF
--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+use App\Models\User;
+use App\Models\Follow;
+
+class FollowController extends Controller
+{
+    public function indexFollowings(User $user) {
+        $followings = $user->followings()->get();
+        $my_following_ids = auth()->user()->followings()->pluck('following_user_id');
+        
+        return Inertia::render('User/IndexFollowings', ['followings' => $followings, 'my_following_ids' => $my_following_ids]);
+    }
+    
+    public function indexFollowers(User $user) {
+        $followers = $user->followers()->get();
+        $my_following_ids = auth()->user()->followings()->pluck('following_user_id');
+        
+        return Inertia::render('User/IndexFollowers', ['followers' => $followers, 'my_following_ids' => $my_following_ids]);
+    }
+    
+    public function store(Request $request, User $user) {
+        $user->followers()->attach(auth()->id());
+        
+        return redirect()->back();
+    }
+    
+    public function destroy(User $user) {
+        $user->followers()->detach(auth()->id());
+        
+        return redirect()->back();
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -9,8 +9,10 @@ use App\Models\User;
 class UserController extends Controller
 {
     public function show($study_record) {
-        $user = User::with('study_records.categories')->where('id', $study_record)->first();
+        $user = User::with('study_records.categories', 'followers', 'followings')->where('id', $study_record)->first();
+        $following_count = $user->followings()->count();
+        $follower_count = $user->followers()->count();
         
-        return Inertia::render('User/Show', ['user' => $user]);
+        return Inertia::render('User/Show', ['user' => $user, 'following_count' => $following_count, 'follower_count' => $follower_count]);
     }
 }

--- a/app/Models/Follow.php
+++ b/app/Models/Follow.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class Follow extends Pivot
+{
+    //
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,7 +30,15 @@ class User extends Authenticatable
         'goal_text',
         'goal_time',
     ];
-     
+
+    public function followings() {
+        return $this->belongsToMany(User::class, 'follows', 'follower_user_id', 'following_user_id')->withTimestamps();
+    }
+
+    public function followers() {
+        return $this->belongsToMany(User::class, 'follows', 'following_user_id', 'follower_user_id')->withTimestamps();
+    }
+    
     public function study_records() {    
         return $this->hasMany(StudyRecord::class);  
     }

--- a/database/migrations/2023_12_19_114958_create_follows_table.php
+++ b/database/migrations/2023_12_19_114958_create_follows_table.php
@@ -13,10 +13,10 @@ return new class extends Migration
      */
     public function up()
     {
-        Schema::create('relationships', function (Blueprint $table) {
+        Schema::create('follows', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('followed_user_id')->constrained('users')->onDelete('cascade');
-            $table->foreignId('folloing_user_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('following_user_id')->constrained('users')->onDelete('cascade');
+            $table->foreignId('follower_user_id')->constrained('users')->onDelete('cascade');
             $table->timestamps();
         });
     }
@@ -28,6 +28,6 @@ return new class extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('relationships');
+        Schema::dropIfExists('follows');
     }
 };

--- a/resources/js/Pages/User/IndexFollowers.jsx
+++ b/resources/js/Pages/User/IndexFollowers.jsx
@@ -1,0 +1,59 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm  } from '@inertiajs/react';
+import PrimaryButton from '@/Components/PrimaryButton';
+
+export default function IndexFollowers(props) {
+    const { delete: destroy, post, processing, errors } = useForm();
+
+    const handleFollow = async (id) => {
+        await post(route("user.follow", id));
+    };
+
+    const handleUnfollow = async (id) => {
+        await destroy(route("user.unfollow", id));
+    }
+    
+    const isfollowed = (id) => props.my_following_ids.includes(id);
+    return (
+        <AuthenticatedLayout
+            auth={props.auth}
+            errors={props.errors}
+            header={
+            <h2 className="font-semibold text-xl text-gray-800 leading-tight">
+                Follower
+            </h2>
+            }
+        >
+            <Head title="User Follower" />
+            {console.log(props.my_following_ids)}
+            <div className="py-12">
+                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                    <div className="">
+                        {props.followers.map((user) => (
+                            <div key={user.id} className="flex p-5 items-center bg-slate-100 border">
+                                <div className="mr-3">
+                                    <img
+                                        className="w-12 h-12 rounded-full ring-2 ring-white"
+                                        src={ user.image_url ? user.image_url : '/images/user_icon.png'}
+                                        alt=""
+                                    />
+                                </div>
+                                <div className="flex-auto">
+                                    <div className="flex justify-between items-center">
+                                        <div className="text-center">{user.name}</div>
+                                        {isfollowed(user.id) ? ( 
+                                            <PrimaryButton onClick={() => handleUnfollow(user.id)} processing={processing}>フォローを外す</PrimaryButton>
+                                        ) : (
+                                            <PrimaryButton onClick={() => handleFollow(user.id)} processing={processing}>フォローする</PrimaryButton>
+                                        )}
+                                    </div>
+                                    <div className="pt-1">{user.text}</div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/User/IndexFollowings.jsx
+++ b/resources/js/Pages/User/IndexFollowings.jsx
@@ -1,0 +1,59 @@
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
+import { Head, useForm  } from '@inertiajs/react';
+import PrimaryButton from '@/Components/PrimaryButton';
+
+export default function IndexFollowings(props) {
+    const { delete: destroy, post, processing, errors } = useForm();
+
+    const handleFollow = async (id) => {
+        await post(route("user.follow", id));
+    };
+
+    const handleUnfollow = async (id) => {
+        await destroy(route("user.unfollow", id));
+    }
+    
+    const isfollowed = (id) => props.my_following_ids.includes(id);
+    
+    return (
+        <AuthenticatedLayout
+            auth={props.auth}
+            errors={props.errors}
+            header={
+            <h2 className="font-semibold text-xl text-gray-800 leading-tight">
+                Follower
+            </h2>
+            }
+        >
+            <Head title="User Follower" />
+            <div className="py-12">
+                <div className="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                    <div className="">
+                        {props.followings.map((user) => (
+                            <div key={user.id} className="flex p-5 items-center bg-slate-100 border">
+                                <div className="mr-3">
+                                    <img
+                                        className="w-12 h-12 rounded-full ring-2 ring-white"
+                                        src={ user.image_url ? user.image_url : '/images/user_icon.png'}
+                                        alt=""
+                                    />
+                                </div>
+                                <div className="flex-auto">
+                                    <div className="flex justify-between items-center">
+                                        <div className="text-center">{user.name}</div>
+                                        {isfollowed(user.id) ? ( 
+                                            <PrimaryButton onClick={() => handleUnfollow(user.id)} processing={processing}>フォローを外す</PrimaryButton>
+                                        ) : (
+                                            <PrimaryButton onClick={() => handleFollow(user.id)} processing={processing}>フォローする</PrimaryButton>
+                                        )}
+                                    </div>
+                                    <div className="pt-1">{user.text}</div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/User/Show.jsx
+++ b/resources/js/Pages/User/Show.jsx
@@ -1,7 +1,20 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, Link } from '@inertiajs/react';
+import { Head, Link, useForm } from '@inertiajs/react';
+import PrimaryButton from '@/Components/PrimaryButton';
 
 export default function Show(props) {
+    const { delete: destroy, post, processing, errors } = useForm();
+    
+    const handleFollow = async (id) => {
+        await post(route("user.follow", id));
+    };
+
+    const handleUnfollow = async (id) => {
+        await destroy(route("user.unfollow", id));
+    }
+    
+    const isfollowed = () => props.user.followers.some(follower => follower.id === props.auth.user.id);
+
     return (
         <AuthenticatedLayout
             auth={props.auth}
@@ -23,6 +36,15 @@ export default function Show(props) {
                                 alt=""
                             />
                             <div className="flex-auto ml-5 text-2xl">{props.user.name}</div>
+                            {isfollowed() ? ( 
+                                <PrimaryButton onClick={() => handleUnfollow(props.user.id)}>フォローを外す</PrimaryButton>
+                            ) : (
+                                <PrimaryButton onClick={() => handleFollow(props.user.id)}>フォローする</PrimaryButton>
+                            )}
+                        </div>
+                        <div className="flex justify-evenly">
+                            <Link href={route("user.followings.index", props.user.id)}>{props.following_count} Followings</Link>
+                            <Link href={route("user.followers.index", props.user.id)}>{props.follower_count} Followers</Link>
                         </div>
                     </div>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\StudyRecordController;
 use App\Http\Controllers\StudyRecordLikeController;
 use App\Http\Controllers\StudyRecordCommentController;
 use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\FollowController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -39,7 +40,12 @@ Route::middleware('auth')->group(function () {
     Route::match(['patch', 'post'], '/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
     
-    Route::get('/user/{user}', [UserController::class, 'show'])->name('user.show');
+    Route::get('/users/{user}', [UserController::class, 'show'])->name('user.show');
+    
+    Route::get('/users/{user}/followings', [FollowController::class, 'indexFollowings'])->name('user.followings.index');
+    Route::get('/users/{user}/followers', [FollowController::class, 'indexFollowers'])->name('user.followers.index');
+    Route::post('/users/{user}/follow', [FollowController::class, 'store'])->name('user.follow');
+    Route::delete('/users/{user}/unfollow', [FollowController::class, 'destroy'])->name('user.unfollow');
     
     Route::resource('/study_records', StudyRecordController::class)
         ->names([


### PR DESCRIPTION
基本のフォロー機能を実装した。
Userモデルにリレーションを書き、followings()はユーザーがフォローしているuser、followers()はユーザーがフォローされているuserを取得するようにした。フォローボタンは各ユーザー画面と、そのフォロー画面、フォロワー画面に表示するようにした。フォロー数やフォロワー数もコントローラーで取得して渡している。isFollowed関数にはコントローラーでログインしているユーザーがフォローしているuser_idに絞って取得して渡すことで、N+1問題を解決した。ルートに関しては、RESTfulを意識した設計にしたが、他の部分との統一が必要になる。