### PR TITLE
いいね機能のリレーション変更

### DIFF
--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -3,10 +3,8 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use App\Models\User;
-use App\Models\Follow;
 
 class FollowController extends Controller
 {
@@ -24,7 +22,7 @@ class FollowController extends Controller
         return Inertia::render('User/IndexFollowers', ['followers' => $followers, 'my_following_ids' => $my_following_ids]);
     }
     
-    public function store(Request $request, User $user) {
+    public function store(User $user) {
         $user->followers()->attach(auth()->id());
         
         return redirect()->back();

--- a/app/Http/Controllers/StudyRecordController.php
+++ b/app/Http/Controllers/StudyRecordController.php
@@ -17,8 +17,9 @@ class StudyRecordController extends Controller
     
     public function show($id) {
         $study_record = StudyRecord::with('user', 'categories', 'study_record_likes', 'study_record_comments.user')->where('id', $id)->first();
+        $like_count = $study_record->study_record_likes()->count();
         
-        return Inertia::render('StudyRecord/Show', ['study_record' => $study_record]);
+        return Inertia::render('StudyRecord/Show', ['study_record' => $study_record, 'like_count' => $like_count]);
     }
     
     public function create() {

--- a/app/Http/Controllers/StudyRecordLikeController.php
+++ b/app/Http/Controllers/StudyRecordLikeController.php
@@ -3,23 +3,19 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use App\Models\StudyRecordLike;
+use App\Models\StudyRecord;
 
 class StudyRecordLikeController extends Controller
 {
-    public function store($study_record) {
-        StudyRecordLike::create([
-            'user_id' => auth()->id(),
-            'study_record_id' => $study_record
-        ]);
+    public function store(StudyRecord $study_record) {
+        $study_record->study_record_likes()->attach(auth()->id());
         
         return redirect()->route('study_record.show', $study_record);
     }
     
-    public function destroy($study_record) {
-        $like = StudyRecordLike::where('study_record_id', $study_record)->where('user_id', auth()->id())->first();
-        $like->delete();
-        
+    public function destroy(StudyRecord $study_record) {
+        $study_record->study_record_likes()->detach(auth()->id());
+
         return redirect()->route('study_record.show', $study_record);
     }
 }

--- a/app/Models/StudyRecord.php
+++ b/app/Models/StudyRecord.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\User;
 use App\Models\Category;
-use App\Models\StudyRecordLike;
 use App\Models\StudyRecordComment;
 
 class StudyRecord extends Model
@@ -31,7 +30,7 @@ class StudyRecord extends Model
     }
     
     public function study_record_likes() {
-        return $this->hasMany(StudyRecordLike::class);
+        return $this->belongsToMany(User::class, 'study_record_likes')->withTimestamps();
     }
     
     public function study_record_comments() {

--- a/app/Models/StudyRecordLike.php
+++ b/app/Models/StudyRecordLike.php
@@ -2,25 +2,9 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
-use App\Models\User;
-use App\Models\StudyRecord;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
-class StudyRecordLike extends Model
+class StudyRecordLike extends Pivot
 {
-    use HasFactory;
-    
-    protected $fillable = [
-        'user_id',
-        'study_record_id'
-    ];
-    
-    public function user() {
-        return $this->belongsTo(User::class);
-    }
-    
-    public function study_record() {
-        return $this->belongsTo(StudyRecord::class);
-    }
+    //
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,7 +9,6 @@ use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 use App\Models\StudyRecord;
 use App\Models\NoteRecord;
-use App\Models\StudyRecordLike;
 use App\Models\StudyRecordComment;
 
 class User extends Authenticatable
@@ -43,8 +42,8 @@ class User extends Authenticatable
         return $this->hasMany(StudyRecord::class);  
     }
     
-    public function study_record_user_likes() {
-        return $this->hasMany(StudyRecordLike::class);
+    public function study_record_likes() {
+        return $this->belongsToMany(StudyRecord::class, 'study_record_likes')->withTimestamps();
     }
     
     public function study_record_comments() {

--- a/resources/js/Pages/StudyRecord/Show.jsx
+++ b/resources/js/Pages/StudyRecord/Show.jsx
@@ -23,14 +23,14 @@ export default function Show(props) {
     };
     
     const handleLike = async (id) => {
-        await post(route("study_record.likes.store", id));
+        await post(route("study_record.like", id));
     };
 
     const handleUnlike = async (id) => {
-        await destroy(route("study_record.likes.destroy", id));
+        await destroy(route("study_record.unlike", id));
     }
     
-    const isliked = () => props.study_record.study_record_likes.some(like => like.user_id === props.auth.user.id);
+    const isLiked = () => props.study_record.study_record_likes.some(like => like.id === props.auth.user.id);
     
     return (
         <AuthenticatedLayout
@@ -62,32 +62,36 @@ export default function Show(props) {
                             <div>{props.study_record.body}</div>
                         </div>          
                     </div>
-                    {isliked() ? (
-                        <button 
-                            className="px-4 py-2 bg-red-500 text-white rounded-lg text-xs font-semibold"
-                            onClick={() => handleUnlike(props.study_record.id)}
-                        >
-                            {props.study_record.study_record_likes.length} いいね済み
-                        </button>
-                        ) : (
-                        <button 
-                            className="px-4 py-2 bg-red-500 text-white rounded-lg text-xs font-semibold"
-                            onClick={() => handleLike(props.study_record.id)}
-                        >
-                            {props.study_record.study_record_likes.length} いいねする
-                        </button>
-                    )}
-                    <Link href={route('study_record.edit', props.study_record.id)}>
-                        <button className="px-4 py-2 bg-green-500 text-white rounded-lg text-xs font-semibold">
-                            更新
-                        </button>
-                    </Link>
-                    <button 
-                        className="px-4 py-2 bg-red-500 text-white rounded-lg text-xs font-semibold"
-                        onClick={() => handleDelete(props.study_record.id)}
-                    >
-                        削除
-                    </button>
+                    <div className="flex space-between">
+                        {isLiked() ? (
+                            <button 
+                                className="px-4 py-2 bg-red-500 text-white rounded-lg text-xs font-semibold"
+                                onClick={() => handleUnlike(props.study_record.id)}
+                            >
+                                {props.like_count} いいね済み
+                            </button>
+                            ) : (
+                            <button 
+                                className="px-4 py-2 bg-red-500 text-white rounded-lg text-xs font-semibold"
+                                onClick={() => handleLike(props.study_record.id)}
+                            >
+                                {props.like_count} いいねする
+                            </button>
+                        )}
+                        {props.auth.user.id === props.study_record.user.id && (
+                            <div>
+                                <button onClick={() => route('study_record.edit', props.study_record.id)}className="px-4 py-2 bg-green-500 text-white rounded-lg text-xs font-semibold">
+                                    更新
+                                </button>
+                                <button 
+                                    className="px-4 py-2 bg-red-500 text-white rounded-lg text-xs font-semibold"
+                                    onClick={() => handleDelete(props.study_record.id)}
+                                >
+                                    削除
+                                </button>
+                            </div>
+                        )}
+                    </div>
                 </div>
                 <div className="max-w-7xl mx-auto sm:px-6 lg:px-8 mb-5">
                     <form onSubmit={submit}>

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,8 +58,8 @@ Route::middleware('auth')->group(function () {
             'show' => 'study_record.show',
         ]);
         
-    Route::post('/study_records/{study_record}/likes', [StudyRecordLikeController::class, 'store'])->name('study_record.likes.store');
-    Route::delete('/study_records/{study_record}/likes', [StudyRecordLikeController::class, 'destroy'])->name('study_record.likes.destroy');
+    Route::post('/study_records/{study_record}/like', [StudyRecordLikeController::class, 'store'])->name('study_record.like');
+    Route::delete('/study_records/{study_record}/unlike', [StudyRecordLikeController::class, 'destroy'])->name('study_record.unlike');
     
     Route::post('/study_records/{study_record}/comments', [StudyRecordCommentController::class, 'store'])->name('study_record.comment.store');
     Route::delete('/study_records/{study_record}/comments/{comment}', [StudyRecordCommentController::class, 'destroy'])->name('study_record.comment.destroy');


### PR DESCRIPTION
belongsTo/hasManyの関係からbelongsToManyに変更した。いいね機能の実装は関係性は多対多であるため、フォロー機能と同様な実装に書き換えた。また、ルートをlikes/store, likes/destroyからlike, unlikeにした。いいね数はコントローラーから取得して表示するようにした。

また、投稿の編集ボタンと削除ボタンをログインユーザーにしか表示されないようにした。