### PR TITLE
ユーザー画面のrecords切り替えボタンの実装

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -11,7 +11,9 @@ class UserController extends Controller
     public function show(User $user) {
         $user->load(['study_records' => function ($query) {
             $query->orderBy('date', 'desc')->orderBy('updated_at', 'desc');
-        }, 'study_records.category', 'followers', 'followings']);
+        }, 'study_records.category', 'note_records' => function ($query) {
+            $query->orderBy('date', 'desc')->orderBy('updated_at', 'desc');
+        }, 'note_records.categories', 'followers', 'followings']);
         
         $following_count = $user->followings()->count();
         $follower_count = $user->followers()->count();

--- a/resources/js/Pages/User/Show.jsx
+++ b/resources/js/Pages/User/Show.jsx
@@ -1,9 +1,14 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, Link, useForm } from '@inertiajs/react';
+import { Head, Link, useForm, useRemember } from '@inertiajs/react';
 import PrimaryButton from '@/Components/PrimaryButton';
 
 export default function Show(props) {
     const { delete: destroy, post, processing, errors } = useForm();
+    const [selectedTab, setSelectedTab] = useRemember('study_records');
+    
+    const handleTabChange = (tab) => {
+        setSelectedTab(tab);
+    }
     
     const handleFollow = async (id) => {
         await post(route("user.follow", id));
@@ -11,7 +16,7 @@ export default function Show(props) {
 
     const handleUnfollow = async (id) => {
         await destroy(route("user.unfollow", id));
-    }
+    };
     
     const isfollowed = () => props.user.followers.some(follower => follower.id === props.auth.user.id);
 
@@ -37,9 +42,9 @@ export default function Show(props) {
                             />
                             <div className="flex-auto ml-5 text-2xl">{props.user.name}</div>
                             {isfollowed() ? ( 
-                                <PrimaryButton onClick={() => handleUnfollow(props.user.id)}>フォローを外す</PrimaryButton>
+                                <PrimaryButton onClick={() => handleUnfollow(props.user.id)} processing={processing}>フォローを外す</PrimaryButton>
                             ) : (
-                                <PrimaryButton onClick={() => handleFollow(props.user.id)}>フォローする</PrimaryButton>
+                                <PrimaryButton onClick={() => handleFollow(props.user.id)} processing={processing}>フォローする</PrimaryButton>
                             )}
                         </div>
                         <div className="flex justify-evenly">
@@ -50,31 +55,83 @@ export default function Show(props) {
                 </div>
             </div>
             <div className="py-20">
-                <div className="w-5/6 m-auto p-10 bg-slate-50 rounded-lg">
-                    <div className="text-center">タイムライン</div>
+                <div className="flex justify-start w-5/6 m-auto">
+                    <label className={`px-4 py-2 ml-10 mr-3 rounded-t-md ${selectedTab === "study_records" ? 'bg-slate-50' : 'bg-slate-200 text-slate-600'}`}>
+                        <input
+                            type="radio"
+                            value="study_records"evenly
+                            checked={selectedTab === "study_records"}
+                            onChange={() => handleTabChange("study_records")}
+                            className ="hidden"
+                        />
+                        学習記録
+                    </label>
+                    <label className={`px-4 py-2 rounded-t-md ${selectedTab === "note_records" ? 'bg-slate-50' : 'bg-slate-200 text-slate-600'}`}>
+                        <input
+                            type="radio"
+                            value="note_records"
+                            checked={selectedTab === "note_records"}
+                            onChange={() => handleTabChange("note_records")}
+                            className="hidden"
+                        />
+                        ノート
+                    </label>
+                </div>
+                <div className="w-5/6 m-auto p-10 bg-slate-50 rounded-t-lg">
                     <div className="p-6 bg-white border-t border-gray-200 overflow-y-auto" style={{ maxHeight: '500px' }}>
-                        {props.user.study_records.map((study_record) => { return (
-                            <Link key={study_record.id} href={route("study_record.show", study_record.id)}>
-                                <div className="bg-red-500 m-5 sm:rounded-lg">
-                                    <div className="flex place-items-center text-white text-sm font-bold pt-3 px-3">
-                                        <Link href={route("user.show", props.user.id)}>
-                                            <img
-                                                className="relative w-8 h-8 rounded-full ring-2 ring-white"
-                                                src={props.user.image_url ? props.user.image_url : '/images/user_icon.png'}
-                                                alt=""
-                                            />
-                                        </Link>
-                                        <div className="mx-2">{props.user.name}</div>
-                                        <div className="mx-2">{study_record.date}</div>
-                                        <div className="bg-lime-300 text-black rounded-full px-2 py-1 mx-2">{study_record.category.name}</div>
-                                    </div>
-                                    <div className="pt-1 pb-5 flex justify-evenly">
-                                        <div className="text-white text-lg font-bold text-center">時間：{study_record.time}分</div>
-                                        <div className="text-white text-lg font-bold text-center">{study_record.title}</div>
-                                    </div>
-                                </div>
-                            </Link>
-                        ); })}
+                        {selectedTab === 'study_records' ? (
+                            <div>
+                                {props.user.study_records.map((study_record) => { return (
+                                    <Link key={study_record.id} href={route("study_record.show", study_record.id)}>
+                                        <div className="bg-red-500 m-5 sm:rounded-lg">
+                                            <div className="flex place-items-center text-white text-sm font-bold pt-3 px-3">
+                                                <Link href={route("user.show", props.user.id)}>
+                                                    <img
+                                                        className="relative w-8 h-8 rounded-full ring-2 ring-white"
+                                                        src={props.user.image_url ? props.user.image_url : '/images/user_icon.png'}
+                                                        alt=""
+                                                    />
+                                                </Link>
+                                                <div className="mx-2">{props.user.name}</div>
+                                                <div className="mx-2">{study_record.date}</div>
+                                                <div className="bg-lime-300 text-black rounded-full px-2 py-1 mx-2">{study_record.category.name}</div>
+                                            </div>
+                                            <div className="pt-1 pb-5 flex justify-evenly">
+                                                <div className="text-white text-lg font-bold text-center">時間：{study_record.time}分</div>
+                                                <div className="text-white text-lg font-bold text-center">{study_record.title}</div>
+                                            </div>
+                                        </div>
+                                    </Link>
+                                ); })}
+                            </div>
+                        ) : (
+                            <div>
+                                {props.user.note_records.map((note_record) => { return (
+                                    <Link key={note_record.id} href={route("note_record.show", note_record.id)}>
+                                        <div className="bg-red-500 m-5 sm:rounded-lg">
+                                            <div className="flex place-items-center text-white text-sm font-bold pt-3 px-3">
+                                                <Link href={route("user.show", props.user.id)}>
+                                                    <img
+                                                        className="relative w-8 h-8 rounded-full ring-2 ring-white"
+                                                        src={props.user.image_url ? props.user.image_url : '/images/user_icon.png'}
+                                                        alt=""
+                                                    />
+                                                </Link>
+                                                <div className="mx-2">{props.user.name}</div>
+                                                <div className="mx-2">{note_record.date}</div>
+                                                {note_record.categories.map((category) => { return (
+                                                    <div key={category.id} className="bg-lime-300 text-black rounded-full px-2 py-1 mx-2">{category.name}</div>
+                                                ); })}
+                                            </div>
+                                            <div className="pt-1 pb-5 flex justify-evenly">
+                                                <div className="text-white text-lg font-bold text-center">時間：{note_record.time}分</div>
+                                                <div className="text-white text-lg font-bold text-center">{note_record.title}</div>
+                                            </div>
+                                        </div>
+                                    </Link>
+                                ); })}
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
ユーザー画面のstudy_recordsとnote_recordsの切り替えをラジオボタンで実装した。RESTfulを意識した実装では、stateを持つべきではないという考え方があるが、それはバックエンドでフロントエンドの状態を持つべきではないというものであったため、inertiaのuseRememberを用いてラジオボタンを実装した。indexとcommunityでは複数のユーザー投稿を取得し、件数が多くなるのとUIの向上のためにルート分けをしたが、今回は一人のユーザー投稿の取得であったため、study_recordsとnote_recordsの投稿を取得し、ラジオボタンで切り替える実装をした。