### PR TITLE
レイアウトの統一

### DIFF
--- a/app/Http/Controllers/FollowController.php
+++ b/app/Http/Controllers/FollowController.php
@@ -11,15 +11,17 @@ class FollowController extends Controller
     public function indexFollowings(User $user) {
         $followings = $user->followings()->get();
         $my_following_ids = auth()->user()->followings()->pluck('following_user_id');
+        $user_id = $user->id;
         
-        return Inertia::render('User/IndexFollowings', ['followings' => $followings, 'my_following_ids' => $my_following_ids]);
+        return Inertia::render('User/IndexFollowings', ['followings' => $followings, 'my_following_ids' => $my_following_ids, 'user_id' => $user_id]);
     }
     
     public function indexFollowers(User $user) {
         $followers = $user->followers()->get();
         $my_following_ids = auth()->user()->followings()->pluck('following_user_id');
+        $user_id = $user->id;
         
-        return Inertia::render('User/IndexFollowers', ['followers' => $followers, 'my_following_ids' => $my_following_ids]);
+        return Inertia::render('User/IndexFollowers', ['followers' => $followers, 'my_following_ids' => $my_following_ids, 'user_id' => $user_id]);
     }
     
     public function store(User $user) {

--- a/resources/js/Layouts/AuthenticatedLayout.jsx
+++ b/resources/js/Layouts/AuthenticatedLayout.jsx
@@ -1,112 +1,57 @@
-import { useState } from 'react';
-import ApplicationLogo from '@/Components/ApplicationLogo';
-import Dropdown from '@/Components/Dropdown';
-import NavLink from '@/Components/NavLink';
-import ResponsiveNavLink from '@/Components/ResponsiveNavLink';
-import { Link } from '@inertiajs/react';
+import { useState } from "react";
+import ResponsiveNavLink from "@/Components/ResponsiveNavLink";
+import { Link } from "@inertiajs/react";
 
 export default function Authenticated({ auth, header, children }) {
     const [showingNavigationDropdown, setShowingNavigationDropdown] = useState(false);
 
     return (
-        <div className="min-h-screen bg-gray-100">
-            <nav className="bg-white border-b border-gray-100">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="min-h-screen bg-gray-100 relative">
+            <div className="fixed top-0 left-0 right-0 z-10">
+                <div className="mx-auto px-4 sm:px-6 lg:px-8 bg-white border-b border-gray-100">
                     <div className="flex justify-between h-16">
-                        <div className="flex">
-                            <div className="shrink-0 flex items-center">
-                                <Link href="/">
-                                    <div className="myfont-semibold text-black">Beginners Pro</div>
-                                </Link>
-                            </div>
-
-                            <div className="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
-                                <NavLink href={route('dashboard')} active={route().current('dashboard')}>
-                                    Dashboard
-                                </NavLink>
-                                <NavLink href={route('study_record.index')} active={route().current('study_record.index')}>
-                                    学習記録
-                                </NavLink>
-                                <NavLink href={route('note_record.index')} active={route().current('note_record.index')}>
-                                    ノート
-                                </NavLink>
-                                <NavLink href={route('category.index')} active={route().current('category.index')}>
-                                    カテゴリー
-                                </NavLink>
-                            </div>
+                        <div className="flex items-center">
+                            <Link href="/">
+                                <div className="font-bold text-black">Beginners Pro</div>
+                            </Link>
                         </div>
-
-                        <div className="hidden sm:flex sm:items-center sm:ml-6">
-                            <div className="ml-3 relative">
-                                <Dropdown>
-                                    <Dropdown.Trigger>
-                                        <span className="inline-flex rounded-md">
-                                            <button
-                                                type="button"
-                                                className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150"
-                                            >
-                                                {auth.user.name}
-
-                                                <svg
-                                                    className="ml-2 -mr-0.5 h-4 w-4"
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    viewBox="0 0 20 20"
-                                                    fill="currentColor"
-                                                >
-                                                    <path
-                                                        fillRule="evenodd"
-                                                        d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                                                        clipRule="evenodd"
-                                                    />
-                                                </svg>
-                                            </button>
-                                        </span>
-                                    </Dropdown.Trigger>
-
-                                    <Dropdown.Content>
-                                        <Dropdown.Link href={route('profile.edit')}>Profile</Dropdown.Link>
-                                        <Dropdown.Link href={route('logout')} method="post" as="button">
-                                            Log Out
-                                        </Dropdown.Link>
-                                    </Dropdown.Content>
-                                </Dropdown>
+                        <div className="flex items-center">
+                            <Link href={route("user.show", auth.user.id)} className="mr-5">
+                                <img
+                                    className="w-10 h-10 rounded-full ring-2 ring-gray-50"
+                                    src={auth.user.image_url ? auth.user.image_url : '/images/user_icon.png'}
+                                    alt=""
+                                />
+                            </Link>
+                            <div className="-mr-2 flex items-center">
+                                <button
+                                    onClick={() => setShowingNavigationDropdown((previousState) => !previousState)}
+                                    className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out"
+                                >
+                                    <svg className="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
+                                        <path
+                                            className={!showingNavigationDropdown ? 'inline-flex' : 'hidden'}
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            strokeWidth="2"
+                                            d="M4 6h16M4 12h16M4 18h16"
+                                        />
+                                        <path
+                                            className={showingNavigationDropdown ? 'inline-flex' : 'hidden'}
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            strokeWidth="2"
+                                            d="M6 18L18 6M6 6l12 12"
+                                        />
+                                    </svg>
+                                </button>
                             </div>
-                        </div>
-
-                        <div className="-mr-2 flex items-center sm:hidden">
-                            <button
-                                onClick={() => setShowingNavigationDropdown((previousState) => !previousState)}
-                                className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out"
-                            >
-                                <svg className="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
-                                    <path
-                                        className={!showingNavigationDropdown ? 'inline-flex' : 'hidden'}
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth="2"
-                                        d="M4 6h16M4 12h16M4 18h16"
-                                    />
-                                    <path
-                                        className={showingNavigationDropdown ? 'inline-flex' : 'hidden'}
-                                        strokeLinecap="round"
-                                        strokeLinejoin="round"
-                                        strokeWidth="2"
-                                        d="M6 18L18 6M6 6l12 12"
-                                    />
-                                </svg>
-                            </button>
                         </div>
                     </div>
                 </div>
 
-                <div className={(showingNavigationDropdown ? 'block' : 'hidden') + ' sm:hidden'}>
-                    <div className="pt-2 pb-3 space-y-1">
-                        <ResponsiveNavLink href={route('dashboard')} active={route().current('dashboard')}>
-                            Dashboard
-                        </ResponsiveNavLink>
-                    </div>
-
-                    <div className="pt-4 pb-1 border-t border-gray-200">
+                <div className={(showingNavigationDropdown ? 'block' : 'hidden') + ' sm:max-w-7xl sm:mx-auto sm:px-4 sm:hidden'}>
+                    <div className="pt-4 pb-1 bg-gray-100 border-t border-gray-200">
                         <div className="px-4">
                             <div className="font-medium text-base text-gray-800">
                                 {auth.user.name}
@@ -115,22 +60,87 @@ export default function Authenticated({ auth, header, children }) {
                         </div>
 
                         <div className="mt-3 space-y-1">
-                            <ResponsiveNavLink href={route('profile.edit')}>Profile</ResponsiveNavLink>
+                            <ResponsiveNavLink href={route('study_record.index')}>
+                                学習記録
+                            </ResponsiveNavLink>
+                            <ResponsiveNavLink href={route('note_record.index')}>
+                                ノート
+                            </ResponsiveNavLink>
+                            <ResponsiveNavLink href={route("category.index")}>
+                                カテゴリー
+                            </ResponsiveNavLink>
+                            <ResponsiveNavLink href={route('profile.edit')}>
+                                プロフィール
+                            </ResponsiveNavLink>
                             <ResponsiveNavLink method="post" href={route('logout')} as="button">
-                                Log Out
+                                ログアウト
                             </ResponsiveNavLink>
                         </div>
                     </div>
                 </div>
-            </nav>
 
-            {header && (
-                <header className="bg-white shadow">
-                    <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">{header}</div>
-                </header>
-            )}
+                {header && (
+                    <header className="bg-white shadow">
+                        <div className="mx-auto py-6 px-4 sm:px-6 lg:px-8">{header}</div>
+                    </header>
+                )}
+            
+                <div className={(showingNavigationDropdown ? 'sm:block' : 'hidden') + ' hidden w-full h-full'}>
+                    <div className="bg-white border-t border-gray-200 fixed inset-y-0 right-0 z-20 w-1/4 border-l border-gray-100">
+                        <div className="flex justify-end h-16 px-4 sm:px-6 lg:px-8">
+                            <div className="-mr-2 flex items-center">
+                                <button
+                                    onClick={() => setShowingNavigationDropdown((previousState) => !previousState)}
+                                    className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out"
+                                >
+                                    <svg className="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
+                                        <path
+                                            className={!showingNavigationDropdown ? 'inline-flex' : 'hidden'}
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            strokeWidth="2"
+                                            d="M4 6h16M4 12h16M4 18h16"
+                                        />
+                                        <path
+                                            className={showingNavigationDropdown ? 'inline-flex' : 'hidden'}
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            strokeWidth="2"
+                                            d="M6 18L18 6M6 6l12 12"
+                                        />
+                                    </svg>
+                                </button>
+                            </div>
+                        </div>
+                        <div className="px-4">
+                            <div className="font-medium text-base text-gray-800">
+                                {auth.user.name}
+                            </div>
+                            <div className="font-medium text-sm text-gray-500">{auth.user.email}</div>
+                        </div>
 
-            <main>{children}</main>
+                        <div className="mt-3 space-y-1">
+                            <ResponsiveNavLink href={route('study_record.index')}>
+                                学習記録
+                            </ResponsiveNavLink>
+                            <ResponsiveNavLink href={route('note_record.index')}>
+                                ノート
+                            </ResponsiveNavLink>
+                            <ResponsiveNavLink href={route("category.index")}>
+                                カテゴリー
+                            </ResponsiveNavLink>
+                            <ResponsiveNavLink href={route('profile.edit')}>
+                                プロフィール
+                            </ResponsiveNavLink>
+                            <ResponsiveNavLink method="post" href={route('logout')} as="button">
+                                ログアウト
+                            </ResponsiveNavLink>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <main className="pt-40">{children}</main>
         </div>
     );
 }

--- a/resources/js/Layouts/GuestLayout.jsx
+++ b/resources/js/Layouts/GuestLayout.jsx
@@ -1,19 +1,24 @@
-import ApplicationLogo from '@/Components/ApplicationLogo';
 import { Link } from '@inertiajs/react';
 
 export default function Guest({ children }) {
     return (
-        <div className="min-h-screen flex flex-col sm:justify-center items-center pt-6 sm:pt-0 bg-gray-100">
-            <div className="w-full sm:max-w-md mt-6 px-6 py-4 bg-white shadow-md overflow-hidden sm:rounded-lg">
-                <div className="w-full sm:fixed sm:top-0 sm:right-0 flex justify-between p-6 text-right border-b-4">
-                    <div className="text-left myfont-semibold text-black">Beginners Pro</div>
-                    <div>
-                            <Link
-                                href='/'
-                                className="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500"
-                            >
-                                Topに戻る
-                            </Link>
+        <div className="min-h-screen flex flex-col sm:justify-center items-center pt-16 sm:pt-0 bg-gray-100 relative">
+            <div className="w-full sm:max-w-md px-6 py-4 bg-white shadow-md overflow-hidden sm:rounded-lg">
+                <div className="fixed top-0 left-0 right-0 z-10">
+                    <div className="mx-auto px-4 sm:px-6 lg:px-8 bg-white border-b">
+                        <div className="flex justify-between items-center h-16">
+                            <div className="font-bold text-black">
+                                Beginners Pro
+                            </div>
+                            <div>
+                                    <Link
+                                        href='/'
+                                        className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                                    >
+                                        Topに戻る
+                                    </Link>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 {children}

--- a/resources/js/Pages/Category/Create.jsx
+++ b/resources/js/Pages/Category/Create.jsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, useForm} from '@inertiajs/react';
+import { Head, Link, useForm } from '@inertiajs/react';
 import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
 import TextInput from '@/Components/TextInput';
@@ -22,13 +22,21 @@ export default function Create(props) {
     
   return (
     <AuthenticatedLayout
-      auth={props.auth}
-      errors={props.errors}
-      header={
-        <h2 className="font-semibold text-xl text-gray-800 leading-tight">
-            Category Create
-        </h2>
-      }
+        auth={props.auth}
+        errors={props.errors}
+        header={
+            <div className="flex justify-between">
+                <div className="font-semibold text-xl text-gray-800">
+                    カテゴリー 作成
+                </div>
+                <Link
+                    href={route("category.index")}
+                    className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                >
+                    一覧に戻る
+                </Link>
+            </div>
+        }
     >
         <Head title="Category Create" />
         <div className="py-12">

--- a/resources/js/Pages/Category/Edit.jsx
+++ b/resources/js/Pages/Category/Edit.jsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, useForm} from '@inertiajs/react';
+import { Head, Link, useForm } from '@inertiajs/react';
 import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
 import TextInput from '@/Components/TextInput';
@@ -22,13 +22,21 @@ export default function Edit(props) {
     
   return (
     <AuthenticatedLayout
-      auth={props.auth}
-      errors={props.errors}
-      header={
-        <h2 className="font-semibold text-xl text-gray-800 leading-tight">
-            Category Create
-        </h2>
-      }
+        auth={props.auth}
+        errors={props.errors}
+        header={
+            <div className="flex justify-between">
+                <div className="font-semibold text-xl text-gray-800">
+                    カテゴリー 編集
+                </div>
+                <Link
+                    href={route("category.index")}
+                    className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                >
+                    戻る
+                </Link>
+            </div>
+        }
     >
         <Head title="Category Create" />
         <div className="py-12">

--- a/resources/js/Pages/Category/Index.jsx
+++ b/resources/js/Pages/Category/Index.jsx
@@ -16,15 +16,18 @@ export default function Index(props) {
     
     return (
         <AuthenticatedLayout
-          auth={props.auth}
-          errors={props.errors}
-          header={
-            <div>
-                <Link href={route("category.create")}>
-                    <PrimaryButton type="button">新規作成</PrimaryButton>
-                </Link>
-            </div>
-          }
+            auth={props.auth}
+            errors={props.errors}
+            header={
+                <div className="flex justify-between">
+                    <div className="font-semibold text-xl text-gray-800">
+                        カテゴリー 一覧
+                    </div>
+                    <Link href={route("category.create")}>
+                        <PrimaryButton type="button">新規作成</PrimaryButton>
+                    </Link>
+                </div>
+            }
         >
             <Head title="Category Index" />
             <div className="py-20">

--- a/resources/js/Pages/Home.jsx
+++ b/resources/js/Pages/Home.jsx
@@ -4,44 +4,48 @@ export default function Welcome(props) {
     return (
         <>
             <Head title="Home" />
-            <div className="relative sm:flex sm:justify-center sm:items-center min-h-screen bg-dots-darker bg-center bg-gray-100 dark:bg-dots-lighter dark:bg-gray-900 selection:bg-red-500 selection:text-white">
-                <div className="w-full sm:fixed sm:top-0 sm:right-0 flex justify-between p-6 border-b-4">
-                    <div className="myfont-semibold text-black">Beginners Pro</div>
-                    <div>
-                        {props.auth.user ? (
-                            <Link
-                                href={route('dashboard')}
-                                className="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500"
-                            >
-                                Dashboard
-                            </Link>
-                        ) : (
-                            <>
-                                <Link
-                                    href={route('login')}
-                                    className="font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500"
-                                >
-                                    Login
-                                </Link>
-    
-                                <Link
-                                    href={route('register')}
-                                    className="ml-4 font-semibold text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white focus:outline focus:outline-2 focus:rounded-sm focus:outline-red-500"
-                                >
-                                    Register
-                                </Link>
-                            </>
-                        )}
+            <div className="min-h-screen bg-gray-100 relative">
+                <div className="fixed top-0 left-0 right-0 z-10">
+                    <div className="mx-auto px-4 sm:px-6 lg:px-8 bg-white border-b">
+                        <div className="flex justify-between items-center h-16">
+                            <div className="font-bold text-black">
+                                Beginners Pro
+                            </div>
+                            <div>
+                                {props.auth.user ? (
+                                    <Link
+                                        href={route('study_record.index')}
+                                        className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                                    >
+                                        記録をする
+                                    </Link>
+                                ) : (
+                                    <div>
+                                        <Link
+                                            href={route('login')}
+                                            className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                                        >
+                                            ログイン
+                                        </Link>
+                
+                                        <Link
+                                            href={route('register')}
+                                            className="ml-4 font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                                        >
+                                            新規登録
+                                        </Link>
+                                    </div>
+                                )}
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <div className="home">
-                    <div className="home-content">
-                        <h1 className="text-6xl text-center font-bold p-10">Beginners Pro</h1>
-                        <p className="text-sm">プログラミング初学者がプロフェッショナルになるための学習記録アプリケーションです。</p>
-                    </div>
+                <div className="pt-72 pb-56 text-center">
+                    <div className="text-6xl font-bold">Beginners Pro</div>
+                    <div className="pt-10 text-sm">プログラミング初学者がプロフェッショナルになるための学習記録アプリケーションです。</div>
                 </div>
-                <div className="w-full h-40 flex sm:fixed sm:bottom-0 sm:right-0 p-6 text-left border-t-4">
-                    <p className="mr-5">© 2023 muranakatakayuki</p>
+                <div className="h-48 p-6 bg-white text-left border-t">
+                    <p className="mr-5 mb-5">© 2023 muranakatakayuki</p>
                     <Link className="mr-5">About</Link>
                     <Link className="mr-5">サイトマップ</Link>
                     <Link className="mr-5">プライバシーポリシー</Link>

--- a/resources/js/Pages/NoteRecord/Community.jsx
+++ b/resources/js/Pages/NoteRecord/Community.jsx
@@ -22,15 +22,18 @@ export default function Index(props) {
     
     return (
         <AuthenticatedLayout
-          auth={props.auth}
-          errors={props.errors}
-          header={
-            <div>
-                <Link href={route("note_record.create")}>
-                    <PrimaryButton type="button">新規作成</PrimaryButton>
-                </Link>
-            </div>
-          }
+            auth={props.auth}
+            errors={props.errors}
+            header={
+                <div className="flex justify-between">
+                    <div className="font-semibold text-xl text-gray-800">
+                        ノート 一覧
+                    </div>
+                    <Link href={route("note_record.create")}>
+                        <PrimaryButton type="button">新規作成</PrimaryButton>
+                    </Link>
+                </div>
+            }
         >
             <Head title="Note_records Index" />
             <div className="py-10">

--- a/resources/js/Pages/NoteRecord/Create.jsx
+++ b/resources/js/Pages/NoteRecord/Create.jsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, useForm } from '@inertiajs/react';
+import { Head, Link, useForm } from '@inertiajs/react';
 import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
 import TextInput from '@/Components/TextInput';
@@ -34,13 +34,21 @@ export default function Create(props) {
     
   return (
     <AuthenticatedLayout
-      auth={props.auth}
-      errors={props.errors}
-      header={
-        <h2 className="font-semibold text-xl text-gray-800 leading-tight">
-            NoteRecords
-        </h2>
-      }
+        auth={props.auth}
+        errors={props.errors}
+        header={
+            <div className="flex justify-between">
+                <div className="font-semibold text-xl text-gray-800">
+                    ノート 作成
+                </div>
+                <Link
+                    href={route("note_record.index")}
+                    className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                >
+                    一覧に戻る
+                </Link>
+            </div>
+        }
     >
         <Head title="Note_records Create" />
         <div className="py-12">

--- a/resources/js/Pages/NoteRecord/Edit.jsx
+++ b/resources/js/Pages/NoteRecord/Edit.jsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, useForm} from '@inertiajs/react';
+import { Head, Link, useForm } from '@inertiajs/react';
 import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
 import TextInput from '@/Components/TextInput';
@@ -37,9 +37,17 @@ export default function Create(props) {
             auth={props.auth}
             errors={props.errors}
             header={
-            <h2 className="font-semibold text-xl text-gray-800 leading-tight">
-                NoteRecords
-            </h2>
+            <div className="flex justify-between">
+                <div className="font-semibold text-xl text-gray-800">
+                    ノート 編集
+                </div>
+                <Link
+                    href={route("note_record.show", props.note_record.id)}
+                    className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                >
+                    戻る
+                </Link>
+            </div>
             }
         >
             <Head title="Note_records Edit" />

--- a/resources/js/Pages/NoteRecord/Index.jsx
+++ b/resources/js/Pages/NoteRecord/Index.jsx
@@ -4,33 +4,20 @@ import PrimaryButton from "@/Components/PrimaryButton";
 import GoalTimeBarChart from "@/Components/GoalTimeBarChart";
 
 export default function Index(props) {
-    
-    const format_time = (time) => {
-        const hours = Math.floor(time / 60);
-        const minutes = time % 60;
-      
-        if (hours === 0) {
-            return `${minutes} 分`;
-        } 
-        
-        if (minutes === 0) {
-            return `${hours} 時間`;
-        }
-        
-        return `${hours} 時間 ${minutes} 分`;
-    };
-    
     return (
         <AuthenticatedLayout
-          auth={props.auth}
-          errors={props.errors}
-          header={
-            <div>
-                <Link href={route("note_record.create")}>
-                    <PrimaryButton type="button">新規作成</PrimaryButton>
-                </Link>
-            </div>
-          }
+            auth={props.auth}
+            errors={props.errors}
+            header={
+                <div className="flex justify-between">
+                    <div className="font-semibold text-xl text-gray-800">
+                        ノート 一覧
+                    </div>
+                    <Link href={route("note_record.create")}>
+                        <PrimaryButton type="button">新規作成</PrimaryButton>
+                    </Link>
+                </div>
+            }
         >
             <Head title="Note_records Index" />
             <div className="py-10">

--- a/resources/js/Pages/NoteRecord/Show.jsx
+++ b/resources/js/Pages/NoteRecord/Show.jsx
@@ -10,6 +10,10 @@ export default function Show(props) {
         comment: ''
     });
     
+    const handleBack = () => {
+        window.history.back();
+    };
+    
     const handleDelete = (id) => {
         destroy(route("note_record.destroy", id));
     };
@@ -38,9 +42,17 @@ export default function Show(props) {
             auth={props.auth}
             errors={props.errors}
             header={
-            <h2 className="font-semibold text-xl text-gray-800 leading-tight">
-                noteRecords
-            </h2>
+                <div className="flex justify-between">
+                    <div className="font-semibold text-xl text-gray-800">
+                        ノート
+                    </div>
+                    <Link
+                        onClick={handleBack}
+                        className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                    >
+                        一覧に戻る
+                    </Link>
+                </div>
             }
         >
             <Head title="note_records Show" />

--- a/resources/js/Pages/Profile/Edit.jsx
+++ b/resources/js/Pages/Profile/Edit.jsx
@@ -8,7 +8,11 @@ export default function Edit({ auth, mustVerifyEmail, status }) {
     return (
         <AuthenticatedLayout
             auth={auth}
-            header={<h2 className="font-semibold text-xl text-gray-800 leading-tight">Profile</h2>}
+            header={
+                <div className="font-semibold text-xl text-gray-800">
+                    プロフィール 編集
+                </div>
+            }
         >
             <Head title="Profile" />
 

--- a/resources/js/Pages/StudyRecord/Community.jsx
+++ b/resources/js/Pages/StudyRecord/Community.jsx
@@ -28,7 +28,10 @@ export default function Community(props) {
             auth={props.auth}
             errors={props.errors}
             header={
-                <div>
+                <div className="flex justify-between">
+                    <div className="font-semibold text-xl text-gray-800">
+                        学習記録 一覧
+                    </div>
                     <Link href={route("study_record.create")}>
                         <PrimaryButton type="button">新規作成</PrimaryButton>
                     </Link>

--- a/resources/js/Pages/StudyRecord/Create.jsx
+++ b/resources/js/Pages/StudyRecord/Create.jsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, useForm } from '@inertiajs/react';
+import { Head, Link, useForm } from '@inertiajs/react';
 import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
 import TextInput from '@/Components/TextInput';
@@ -30,13 +30,21 @@ export default function Create(props) {
     
   return (
     <AuthenticatedLayout
-      auth={props.auth}
-      errors={props.errors}
-      header={
-        <h2 className="font-semibold text-xl text-gray-800 leading-tight">
-            StudyRecords
-        </h2>
-      }
+        auth={props.auth}
+        errors={props.errors}
+        header={
+            <div className="flex justify-between">
+                <div className="font-semibold text-xl text-gray-800">
+                    学習記録 作成
+                </div>
+                <Link
+                    href={route("study_record.index")}
+                    className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                >
+                    一覧に戻る
+                </Link>
+            </div>
+        }
     >
         <Head title="Study_records Create" />
         <div className="py-12">

--- a/resources/js/Pages/StudyRecord/Edit.jsx
+++ b/resources/js/Pages/StudyRecord/Edit.jsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, useForm} from '@inertiajs/react';
+import { Head, Link, useForm } from '@inertiajs/react';
 import InputError from '@/Components/InputError';
 import InputLabel from '@/Components/InputLabel';
 import TextInput from '@/Components/TextInput';
@@ -33,9 +33,17 @@ export default function Edit(props) {
             auth={props.auth}
             errors={props.errors}
             header={
-            <h2 className="font-semibold text-xl text-gray-800 leading-tight">
-                StudyRecords
-            </h2>
+                <div className="flex justify-between">
+                    <div className="font-semibold text-xl text-gray-800">
+                        学習記録 編集
+                    </div>
+                    <Link
+                        href={route("study_record.show", props.study_record.id)}
+                        className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                    >
+                        戻る
+                    </Link>
+                </div>
             }
         >
             <Head title="Study_records Edit" />

--- a/resources/js/Pages/StudyRecord/Index.jsx
+++ b/resources/js/Pages/StudyRecord/Index.jsx
@@ -28,7 +28,10 @@ export default function Index(props) {
             auth={props.auth}
             errors={props.errors}
             header={
-                <div>
+                <div className="flex justify-between">
+                    <div className="font-semibold text-xl text-gray-800">
+                        学習記録 一覧
+                    </div>
                     <Link href={route("study_record.create")}>
                         <PrimaryButton type="button">新規作成</PrimaryButton>
                     </Link>

--- a/resources/js/Pages/StudyRecord/Show.jsx
+++ b/resources/js/Pages/StudyRecord/Show.jsx
@@ -25,6 +25,10 @@ export default function Show(props) {
         return `${hours} 時間 ${minutes} 分`;
     };
     
+    const handleBack = () => {
+        window.history.back();
+    };
+    
     const handleDelete = (id) => {
         destroy(route("study_record.destroy", id));
     };
@@ -53,9 +57,17 @@ export default function Show(props) {
             auth={props.auth}
             errors={props.errors}
             header={
-            <h2 className="font-semibold text-xl text-gray-800 leading-tight">
-                StudyRecords
-            </h2>
+                <div className="flex justify-between">
+                    <div className="font-semibold text-xl text-gray-800">
+                        学習記録
+                    </div>
+                    <Link
+                        onClick={handleBack}
+                        className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                    >
+                        戻る
+                    </Link>
+                </div>
             }
         >
             <Head title="Study_records Show" />

--- a/resources/js/Pages/User/IndexFollowers.jsx
+++ b/resources/js/Pages/User/IndexFollowers.jsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, useForm  } from '@inertiajs/react';
+import { Head, Link, useForm } from '@inertiajs/react';
 import PrimaryButton from '@/Components/PrimaryButton';
 
 export default function IndexFollowers(props) {
@@ -19,9 +19,17 @@ export default function IndexFollowers(props) {
             auth={props.auth}
             errors={props.errors}
             header={
-            <h2 className="font-semibold text-xl text-gray-800 leading-tight">
-                Follower
-            </h2>
+                <div className="flex justify-between">
+                    <div className="font-semibold text-xl text-gray-800">
+                        フォロワー
+                    </div>
+                    <Link
+                        href={route("user.show", props.user_id)}
+                        className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                    >
+                        戻る
+                    </Link>
+                </div>
             }
         >
             <Head title="User Follower" />

--- a/resources/js/Pages/User/IndexFollowings.jsx
+++ b/resources/js/Pages/User/IndexFollowings.jsx
@@ -1,5 +1,5 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
-import { Head, useForm  } from '@inertiajs/react';
+import { Head, Link, useForm  } from '@inertiajs/react';
 import PrimaryButton from '@/Components/PrimaryButton';
 
 export default function IndexFollowings(props) {
@@ -20,9 +20,17 @@ export default function IndexFollowings(props) {
             auth={props.auth}
             errors={props.errors}
             header={
-            <h2 className="font-semibold text-xl text-gray-800 leading-tight">
-                Follower
-            </h2>
+                <div className="flex justify-between">
+                    <div className="font-semibold text-xl text-gray-800">
+                        フォロー
+                    </div>
+                    <Link
+                        href={route("user.show", props.user_id)}
+                        className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                    >
+                        戻る
+                    </Link>
+                </div>
             }
         >
             <Head title="User Follower" />

--- a/resources/js/Pages/User/Show.jsx
+++ b/resources/js/Pages/User/Show.jsx
@@ -8,7 +8,11 @@ export default function Show(props) {
     
     const handleTabChange = (tab) => {
         setSelectedTab(tab);
-    }
+    };
+    
+    const handleBack = () => {
+        window.history.back();
+    };
     
     const handleFollow = async (id) => {
         await post(route("user.follow", id));
@@ -25,9 +29,17 @@ export default function Show(props) {
             auth={props.auth}
             errors={props.errors}
             header={
-            <h2 className="font-semibold text-xl text-gray-800 leading-tight">
-                User
-            </h2>
+                <div className="flex justify-between">
+                    <div className="font-semibold text-xl text-gray-800">
+                        ユーザー
+                    </div>
+                    <Link
+                        onClick={handleBack}
+                        className="font-semibold text-gray-600 underline decoration-solid hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                    >
+                        戻る
+                    </Link>
+                </div>
             }
         >
             <Head title="User Show" />


### PR DESCRIPTION
ログイン前とログイン後のレイアウトを統一させた。
laravel breezeのレイアウトを基準に、各ページのheaderに名前とLinkを貼ることによって今いるページを明確にし、接続性を向上させた。リンク先が複数ある場合は、window.history.back()を利用して前のページを表示させた。学習記録ページやプロフィール編集ページはハンバーガーメニューでリスト化することによって見やすくした。