### PR TITLE
lexicalの未入力状態のカスタム

### DIFF
--- a/resources/js/LexicalPlugins/ExportPlugin.jsx
+++ b/resources/js/LexicalPlugins/ExportPlugin.jsx
@@ -1,15 +1,21 @@
 import { useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $isRootTextContentEmpty } from "@lexical/text";
 
 export default function ExportPlugin({onChange}) {
     const [editor] = useLexicalComposerContext();
-    
+
     useEffect(() => {
         if(onChange) {
             editor.registerUpdateListener(({editorState}) => {
                 editorState.read(() => {
-                    const contentAsJSON = JSON.stringify(editorState);
-                    onChange(contentAsJSON);
+                    const isEmpty = $isRootTextContentEmpty(editor.isComposing());
+                    if (isEmpty) {
+                        onChange("");
+                    } else {
+                        const contentAsJSON = JSON.stringify(editorState);
+                        onChange(contentAsJSON);
+                    }
                 });
             });
         }


### PR DESCRIPTION
lexicalのExportPluginでは未入力の状態で送信すると空ではなくなってしまう。そこでlexicalの入力が空である状態を同期的に取得して、trueである場合に空文字を返す実装をした。

useLexicalIsTextContentEmptyはuseLayoutEffectを用いているためDOMの更新前の情報を取得してしまう。それは、アルファベット１文字の場合、その前の空の状態を取得するため、isEmptyがtrueになっていた。それをuseEffect内で直接取得する実装にすることで同期的な処理となった。 