### PR TITLE
CAST文の削除

### DIFF
--- a/app/Http/Controllers/StudyRecordController.php
+++ b/app/Http/Controllers/StudyRecordController.php
@@ -112,7 +112,7 @@ class StudyRecordController extends Controller
             ->where('users.id', auth()->id())
             ->join('study_records', 'users.id', '=', 'study_records.user_id')
             ->join('categories', 'study_records.category_id', '=', 'categories.id')
-            ->select('categories.id', 'categories.name', 'categories.color', DB::raw('CAST(SUM(study_records.time) AS UNSIGNED) as time'))
+            ->select('categories.id', 'categories.name', 'categories.color', DB::raw('SUM(study_records.time) as time'))
             ->groupBy('categories.id', 'categories.name', 'categories.color')
             ->orderBy('time', 'desc')
             ->get();
@@ -268,7 +268,7 @@ class StudyRecordController extends Controller
             ->where('users.id', auth()->id())
             ->join('study_records', 'users.id', '=', 'study_records.user_id')
             ->join('categories', 'study_records.category_id', '=', 'categories.id')
-            ->select('categories.id', 'categories.name', 'categories.color', DB::raw('CAST(SUM(study_records.time) AS UNSIGNED) as time'))
+            ->select('categories.id', 'categories.name', 'categories.color', DB::raw('SUM(study_records.time) as time'))
             ->groupBy('categories.id', 'categories.name', 'categories.color')
             ->orderBy('time', 'desc')
             ->get();


### PR DESCRIPTION
CAST文を削除した。
cloud9の開発環境からHerokuでのデプロイをする段階で、study_record.indexとstudy_record.communityだけリダイレクトされてしまうため、原因を調べたところ、データベースの違いによって構文が異なることであるとわかった。

MySQLだと、
CAST(SUM(study_records.time) AS UNSIGNED)
という構文で良いが、PostgreSQLでは、
study_records.time::UNSIGNED
という構文である。

データベースの種類によって書き方が異なる部分があるため、今後注意が必要である。