### PR TITLE
画像サイズの制限追加

### DIFF
--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -19,7 +19,7 @@ class ProfileUpdateRequest extends FormRequest
             'name' => ['required', 'string', 'max:10'],
             'email' => ['required', 'email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
             'text' => ['nullable','string', 'max:500'],
-            'image' => ['nullable', 'file'],
+            'image' => ['nullable', 'file', 'max:1024'],
             'delete_image' => ['nullable', 'boolean'],
             'goal_text' => ['nullable', 'string', 'max:100'],
             'goal_time' => ['nullable', 'integer', 'max:10080'],
@@ -30,6 +30,7 @@ class ProfileUpdateRequest extends FormRequest
     {
         return [
             'goal_time.max' => '168時間以内で設定してください。',
+            'image.max' => '1MB以内で設定してください。'
         ];
     }
 }

--- a/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
+++ b/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.jsx
@@ -94,7 +94,7 @@ export default function UpdateProfileInformation({ mustVerifyEmail, status, clas
             </header>
             <form onSubmit={submit} className="mt-6 space-y-6">
                 <div>
-                    <InputLabel>プロフィール画像</InputLabel>
+                    <InputLabel>プロフィール画像（1MB以内）</InputLabel>
                     <div className="mt-1 flex items-center">
                         <img
                             id="preview"


### PR DESCRIPTION
画像保存にcloudinaryの無料プランを使用しているが、１MB以上のファイルは保存に失敗するため、１MB以内という制限を設けた。